### PR TITLE
change allowed response code

### DIFF
--- a/atapt/atapt.py
+++ b/atapt/atapt.py
@@ -189,7 +189,7 @@ class atapt:
     def checkSense(self):
         response_code = 0x7f & int.from_bytes(
             self.sense[0], byteorder='little')
-        if response_code >= 0x72:
+        if response_code >= 0x70:
             sense_key = 0xf & int.from_bytes(self.sense[1], byteorder='little')
             asc = self.sense[2]
             ascq = self.sense[3]


### PR DESCRIPTION
Судя по исходникам smartmontools (https://www.smartmontools.org/static/doxygen/scsiata_8cpp_source.html#l00067) разрешенные коды ответов начинаются с 0x70. У меня есть дисковая полка на которой это подтверждается экспериментально.